### PR TITLE
Escape `$alphabetic_code` in exception message

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -93,7 +93,7 @@ class Currency implements JsonSerializable {
 			throw new \InvalidArgumentException(
 				\sprintf(
 					'The alphabetical code of a currency must consist of 3 characters: %s.',
-					$alphabetic_code
+					\esc_html( $alphabetic_code )
 				)
 			);
 		}


### PR DESCRIPTION
Fixes https://github.com/pronamic/wp-money/issues/9.